### PR TITLE
https://github.com/AppsDevTeam/ErrorLogger/pull/2

### DIFF
--- a/src/DI/TracyGitExtension.php
+++ b/src/DI/TracyGitExtension.php
@@ -31,11 +31,16 @@ class TracyGitExtension extends \Nette\DI\CompilerExtension {
 				}
 				break;
 		}
+
+		$this->getContainerBuilder()
+			->addDefinition($this->prefix('git'))
+			->setClass(\ADT\TracyGit\Git::class)
+			->setArguments([ $config ]);
 	}
 
 	public function afterCompile(Nette\PhpGenerator\ClassType $class) {
 		$initMethod = $class->methods['initialize'];
-		$initMethod->addBody('$this->getService(?)->addPanel(new ' . \ADT\TracyGit\GitPanel::class . '(new ' . \ADT\TracyGit\Git::class . '(?)));', [ 'tracy.bar', $this->config ]);
+		$initMethod->addBody('$this->getService(?)->addPanel(new ' . \ADT\TracyGit\GitPanel::class . '($this->getService(?)));', [ 'tracy.bar', 'tracy.git' ]);
 	}
 
 

--- a/src/DI/TracyGitExtension.php
+++ b/src/DI/TracyGitExtension.php
@@ -35,7 +35,7 @@ class TracyGitExtension extends \Nette\DI\CompilerExtension {
 
 	public function afterCompile(Nette\PhpGenerator\ClassType $class) {
 		$initMethod = $class->methods['initialize'];
-		$initMethod->addBody('$this->getService(?)->addPanel(new ' . \ADT\TracyGit\GitPanel::class . '(?));', [ 'tracy.bar', $this->config ]);
+		$initMethod->addBody('$this->getService(?)->addPanel(new ' . \ADT\TracyGit\GitPanel::class . '(new ' . \ADT\TracyGit\Git::class . '(?)));', [ 'tracy.bar', $this->config ]);
 	}
 
 

--- a/src/DI/TracyGitExtension.php
+++ b/src/DI/TracyGitExtension.php
@@ -40,7 +40,7 @@ class TracyGitExtension extends \Nette\DI\CompilerExtension {
 
 	public function afterCompile(Nette\PhpGenerator\ClassType $class) {
 		$initMethod = $class->methods['initialize'];
-		$initMethod->addBody('$this->getService(?)->addPanel(new ' . \ADT\TracyGit\GitPanel::class . '($this->getService(?)));', [ 'tracy.bar', 'tracy.git' ]);
+		$initMethod->addBody('$this->getService(?)->addPanel(new ' . \ADT\TracyGit\GitPanel::class . '($this->getService(?)));', [ 'tracy.bar', $this->prefix('git') ]);
 	}
 
 

--- a/src/Git.php
+++ b/src/Git.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace ADT\TracyGit;
+
+class Git {
+
+	protected $config;
+
+	public function __construct($config) {
+		$this->config = $config;
+	}
+
+	public function getInfo() {
+		switch ($this->config['provider']) {
+			case DI\TracyGitExtension::PROVIDER_JSON:
+				return file_exists($this->config['file'])
+					? \Nette\Utils\Json::decode(file_get_contents($this->config['file']))
+					: NULL;
+
+			default:
+				throw new DI\TracyGitException('Unknown provider specified');
+		}
+	}
+
+}

--- a/src/GitPanel.php
+++ b/src/GitPanel.php
@@ -6,8 +6,8 @@ class GitPanel implements \Tracy\IBarPanel {
 
 	protected $gitInfo;
 
-	public function __construct($config) {
-		$this->gitInfo = $this->getGitInfo($config);
+	public function __construct(Git $git) {
+		$this->gitInfo = $git->getInfo();
 	}
 
 	public function getTab() {
@@ -25,15 +25,4 @@ class GitPanel implements \Tracy\IBarPanel {
 		return ob_get_clean();
 	}
 
-	private function getGitInfo($config) {
-		switch ($config['provider']) {
-			case DI\TracyGitExtension::PROVIDER_JSON:
-				return file_exists($config['file'])
-					? \Nette\Utils\Json::decode(file_get_contents($config['file']))
-					: NULL;
-
-			default:
-				throw new DI\TracyGitException('Unknown provider specified');
-		}
-	}
 }


### PR DESCRIPTION
@Danoha 
1. určitě bych `adt/tracy-git` nedával jako nutnou závislost, spíš jako doporučenou, jestli to nějak jde,
2. jestli je v aplikaci tracy-git můžeš zjistit z kontejneru - existuje `\ADT\TracyGit\GitInfoService`? To tam teď není, takže bude potřeba upravit tracy-git.
3. vůbec se nemůžeš spoléhat na to, že to git info je v APP_DIR/app.json, místo toho si z kontejneru vytáhni tu servisu a na ní zavolej `->getInfo()`, ta se postará o cestu a dekódování JSONu (tracy-git je totiž navržený tak, že to vůbec nemusí být JSON).